### PR TITLE
Prepare Cyphon for PyPI distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.egg-info
+dist/
 __pycache__
 .coverage
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
+build/
 dist/
 __pycache__
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - pip install codecov
   - pip install coveralls
   - pip install codacy-coverage
-  - python setup.py install
 
 before_script:
   - psql -U postgres -c "create extension postgis"
@@ -54,6 +53,7 @@ script:
   # use --keepdb to avoid OperationalError during teardown in case any
   # db connections are still open from threads in TransactionTestCases
   - cd cyphon
+  - rm -f __init__.py
   - coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,11 @@ install:
   - pip install codecov
   - pip install coveralls
   - pip install codacy-coverage
+  - python setup.py install
 
 before_script:
   - psql -U postgres -c "create extension postgis"
-  - docker-compose -f docker-compose.travis.yml up --build -d 
+  - docker-compose -f docker-compose.travis.yml up --build -d
   - sleep 15  # wait for PostgreSQl and Elasticsearch to start
 
 script:

--- a/cyphon/__init__.py
+++ b/cyphon/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Dunbar Security Solutions, Inc.
+#
+# This file is part of Cyphon Engine.
+#
+# Cyphon Engine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# Cyphon Engine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Cyphon Engine. If not, see <http://www.gnu.org/licenses/>.
+"""Cyphon Engine"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,14 @@
 
 """
 import os
+from pip.download import PipSession
 from pip.req import parse_requirements
 from setuptools import find_packages, setup
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
-INSTALL_REQS = parse_requirements('requirements.txt')
+INSTALL_REQS = parse_requirements(
+    'requirements.txt',
+    session=PipSession())
 
 # reqs is a list of requirements
 # e.g. ['django==1.5.1', 'mezzanine==1.4.6']


### PR DESCRIPTION
- Added ``__init__.py`` to cyphon directory
- FIxed issue with ``setup.py`` where ``parse_requirements`` was called with an incorrect number of arguments
- Added ``setup.cfg`` file with ``bdist_wheel.universal`` set to True, but should be disabled if Python 2 support isn't anticipated.