### PR TITLE
Add UID and GID as build args to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ FROM python:3.6
 
 MAINTAINER Leila Hadj-Chikh <leila.hadj-chikh@dunbarsecured.com>
 
+ARG UID=1000
+ARG GID=1000
+
 ENV CYPHON_HOME /usr/src/app
 ENV LOG_DIR     /var/log/cyphon
 ENV PATH        $PATH:$CYPHON_HOME
@@ -38,7 +41,7 @@ RUN apt-get update && apt-get install -y \
       sendmail
 
 # create unprivileged user
-RUN groupadd -r cyphon && useradd -r -g cyphon cyphon
+RUN groupadd -r -g $GID cyphon && useradd -r -g cyphon -u $UID cyphon
 
 # create application subdirectories
 RUN mkdir -p $CYPHON_HOME \


### PR DESCRIPTION
I had to make this modification to the Dockerfile for Cyphon to work in my Ubuntu 14.04 environment, as my user has UID 1000 but the user created in the container had UID 999 for some reason. I believe docker-compose supports UID/GID mapping as of their version 3 syntax, but we are using version 2 and I wasn't sure how much effort would be required updating to version 3. 