### PR TITLE
Tox configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,7 @@ omit =
   */tests/*
   */migrations/*
 source =
-  cyphon
+  .
 
 [report]
 exclude_lines =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+omit =
+  */tests/*
+  */migrations/*
+
+[report]
+exclude_lines =
+    def __repr__
+    raise NotImplementedError
+    pass
+
+[paths]
+source =
+  cyphon
+  .tox/*/lib/python*/site-packages/cyphon
+  .tox/pypy*/site-packages/cyphon

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,12 +2,17 @@
 omit =
   */tests/*
   */migrations/*
+source =
+  cyphon
 
 [report]
 exclude_lines =
     def __repr__
     raise NotImplementedError
     pass
+omit =
+  */tests/*
+  */migrations/*
 
 [paths]
 source =

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .tox/
 .python-version
-coverage.*.xml
+.coverage*
 *.egg-info
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .tox/
 .python-version
-.coverage*
+.coverage
+.coverage.*
 *.egg-info
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.tox/
+.python-version
+coverage.*.xml
 *.egg-info
 build/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.xml
 .tox/
 .python-version
 .coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ before_script:
 script:
   # copy GeoLite database to shared volume
   - sudo docker cp cyphon_geoip_1:/usr/share/GeoIP/GeoLite2-City.mmdb $GEOIP_PATH
-  - ls -l /home/travis/build/dunbarcyber/cyphon/GeoIP/
-  - tox -v
+  - tox
 
 after_script:
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ script:
 
 after_script:
   - cd ../
-  - docker-compose down
+  - docker-compose -f docker-compose.travis.yml down

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ python:
   - "3.6"
 
 install:
-  - pip install -r requirements.txt
-  - pip install codacy-coverage
-  - pip install codecov
-  - pip install coveralls
   - pip install tox-travis
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
 
 script:
   # copy GeoLite database to shared volume
-  - docker cp cyphon_geoip_1:/usr/share/GeoIP/GeoLite2-City.mmdb $GEOIP_PATH
+  - sudo docker cp cyphon_geoip_1:/usr/share/GeoIP/GeoLite2-City.mmdb $GEOIP_PATH
   - ls -l /home/travis/build/dunbarcyber/cyphon/GeoIP/
   - tox -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
   # copy GeoLite database to shared volume
   - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphon
   - ls -l /home/travis/build/dunbarcyber/cyphon/GeoIP/
-  - tox
+  - tox -v
 
 after_script:
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,13 +32,17 @@ addons:
   sauce_connect: true
 
 python:
-  - 3.6
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install:
   - pip install -r requirements.txt
+  - pip install codacy-coverage
   - pip install codecov
   - pip install coveralls
-  - pip install codacy-coverage
+  - pip install tox-travis
 
 before_script:
   - psql -U postgres -c "create extension postgis"

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,11 +53,6 @@ script:
   - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphon
   - tox
 
-after_success:
-  - coveralls
-  - codecov -f .coverage
-  - python-codacy-coverage -r .coverage
-
 after_script:
   - cd ../
   - docker-compose down

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
   sauce_connect: true
 
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,22 +50,14 @@ before_script:
   - sleep 15  # wait for PostgreSQl and Elasticsearch to start
 
 script:
-
   # copy GeoLite database to shared volume
-  - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphondock
-
-  # use --keepdb to avoid OperationalError during teardown in case any
-  # db connections are still open from threads in TransactionTestCases
-  - cd cyphon
-  - rm -f __init__.py
-  - coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
+  - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphon
+  - tox
 
 after_success:
-  - coverage
   - coveralls
-  - codecov
-  - coverage xml
-  - python-codacy-coverage -r coverage.xml
+  - codecov -f .coverage
+  - python-codacy-coverage -r .coverage
 
 after_script:
   - cd ../

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
 
 script:
   # copy GeoLite database to shared volume
-  - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphon
+  - docker cp cyphon_geoip_1:/usr/share/GeoIP/GeoLite2-City.mmdb $GEOIP_PATH
   - ls -l /home/travis/build/dunbarcyber/cyphon/GeoIP/
   - tox -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
 script:
   # copy GeoLite database to shared volume
   - docker exec cyphon_geoip_1 cp /usr/share/GeoIP/GeoLite2-City.mmdb /usr/share/cyphon
+  - ls -l /home/travis/build/dunbarcyber/cyphon/GeoIP/
   - tox
 
 after_script:

--- a/cyphon/aggregator/filters/tests/test_services.py
+++ b/cyphon/aggregator/filters/tests/test_services.py
@@ -19,7 +19,10 @@ Tests Filter services.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/aggregator/pipes/tests/test_models.py
+++ b/cyphon/aggregator/pipes/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the Pipe class and the related RateLimit and SpecSheet classes.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/aggregator/pumproom/tests/test_faucet.py
+++ b/cyphon/aggregator/pumproom/tests/test_faucet.py
@@ -20,7 +20,10 @@ Tests the Faucet class.
 
 # standard library
 from unittest import skip
-from unittest.mock import Mock, call, patch
+try:
+    from unittest.mock import Mock, call, patch
+except ImportError:
+    from mock import Mock, call, patch
 
 # third party
 from django.contrib.auth import get_user_model
@@ -168,7 +171,7 @@ class SendToChutesTestCase(FaucetTestCase):
         """
         data = [Mock()]
         with patch('sifter.datasifter.datachutes.models.DataChute.bulk_process') \
-                   as mock_process: 
+                   as mock_process:
             search_count = DataChute.objects.find_enabled()\
                                       .filter(endpoint=self.search_faucet.endpoint).count()
             stream_count = DataChute.objects.find_enabled()\
@@ -176,7 +179,7 @@ class SendToChutesTestCase(FaucetTestCase):
             self.search_faucet.send_to_chutes(data)
             self.assertEqual(mock_process.call_count, search_count)
 
-            self.stream_faucet.send_to_chutes(data)            
+            self.stream_faucet.send_to_chutes(data)
             self.assertEqual(mock_process.call_count, stream_count)
             self.assertEqual(mock_process.call_args, call(data=data))
 

--- a/cyphon/aggregator/pumproom/tests/test_pump.py
+++ b/cyphon/aggregator/pumproom/tests/test_pump.py
@@ -19,7 +19,10 @@ Tests the Pump class.
 """
 
 # standard library
-from unittest.mock import Mock, call, patch
+try:
+    from unittest.mock import Mock, call, patch
+except ImportError:
+    from mock import Mock, call, patch
 
 # third party
 from django.contrib.auth import get_user_model

--- a/cyphon/aggregator/pumproom/tests/test_pumproom.py
+++ b/cyphon/aggregator/pumproom/tests/test_pumproom.py
@@ -19,7 +19,10 @@ Tests the PumpRoom class.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # local
 from aggregator.pumproom.tests.test_pump import PumpBaseTestCase

--- a/cyphon/aggregator/pumproom/tests/test_stream.py
+++ b/cyphon/aggregator/pumproom/tests/test_stream.py
@@ -19,7 +19,10 @@ Tests the StreamController class.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.contrib.auth import get_user_model

--- a/cyphon/alerts/tests/test_admin.py
+++ b/cyphon/alerts/tests/test_admin.py
@@ -19,7 +19,10 @@ Tests AlertAdmin methods.
 """
 
 # standard library
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.contrib import admin

--- a/cyphon/alerts/tests/test_models.py
+++ b/cyphon/alerts/tests/test_models.py
@@ -21,7 +21,10 @@ Tests Alert model methods.
 # standard library
 import datetime
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.test import TestCase
@@ -149,14 +152,14 @@ class AlertCompanyTestCase(AlertModelTestCase):
         company.
         """
         alert = Alert.objects.get(pk=1)
-        self.assertEqual(alert.company, None) 
+        self.assertEqual(alert.company, None)
 
     def test_without_distillery(self):
         """
         Tests the company property when the Alert has no Distillery.
         """
         alert = Alert.objects.get(pk=7)
-        self.assertEqual(alert.company, None) 
+        self.assertEqual(alert.company, None)
 
 
 class AlertContentDateTestCase(AlertModelTestCase):

--- a/cyphon/alerts/tests/test_views.py
+++ b/cyphon/alerts/tests/test_views.py
@@ -21,7 +21,10 @@ Tests Alert views.
 # standard library
 from datetime import timedelta
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.conf import settings

--- a/cyphon/bottler/containers/tests/test_models.py
+++ b/cyphon/bottler/containers/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the Container class.
 
 # standard library
 from collections import OrderedDict
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase
@@ -314,5 +317,5 @@ class ContainerTestCase(TestCase):
         "profile_pic": "URLField",
         "screen_name": "CharField (Account)"
     }
-}"""     
+}"""
         self.assertEqual(actual, expected)

--- a/cyphon/codebooks/tests/test_models.py
+++ b/cyphon/codebooks/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the CodeBook, RealName, and CodeName classes.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/contexts/tests/test_models.py
+++ b/cyphon/contexts/tests/test_models.py
@@ -21,7 +21,10 @@ Tests the Context class.
 # standard library
 from datetime import timedelta
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.core.exceptions import ValidationError

--- a/cyphon/cyphon/fieldsets.py
+++ b/cyphon/cyphon/fieldsets.py
@@ -18,6 +18,7 @@
 Defines a |QueryFieldset| class. |QueryFieldsets| are used to construct
 queries to data stores.
 """
+import collections
 
 # local
 from cyphon.choices import FIELD_TYPE_CHOICES, OPERATOR_CHOICES
@@ -64,13 +65,11 @@ class QueryFieldset(object):
         assert self.operator in self.OPERATORS
 
     def __str__(self):
-        return "%s: %s" % (self.__class__.__name__, self.__dict__)
-
-    @property
-    def __dict__(self):
-        return {
-            'field_name': self.field_name,
-            'field_type': self.field_type,
-            'operator': self.operator,
-            'value': self.value
-        }
+        items = collections.OrderedDict([
+            ('field_name', self.field_name),
+            ('field_type', self.field_type),
+            ('operator', self.operator),
+            ('value', self.value),
+        ])
+        items_str = '{' + ', '.join('%r: %r' % i for i in items.items()) + '}'
+        return "%s: %s" % (self.__class__.__name__, items_str)

--- a/cyphon/cyphon/tests/helpers.py
+++ b/cyphon/cyphon/tests/helpers.py
@@ -19,7 +19,10 @@ Tests custom permissions classes.
 """
 
 # standard library
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase

--- a/cyphon/cyphon/tests/test_tasks.py
+++ b/cyphon/cyphon/tests/test_tasks.py
@@ -19,7 +19,10 @@ Tests Permissions classes.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -20,7 +20,10 @@ Tests for the locking database tables.
 
 # standard library
 from unittest import TestCase
-from unittest.mock import patch, Mock
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.db import transaction

--- a/cyphon/distilleries/tests/test_models.py
+++ b/cyphon/distilleries/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the Distillery class.
 
 # standard library
 import copy
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 import dateutil.parser

--- a/cyphon/distilleries/tests/test_signals.py
+++ b/cyphon/distilleries/tests/test_signals.py
@@ -19,7 +19,10 @@ Tests signals for Distilleries.
 """
 
 # standard library
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TransactionTestCase

--- a/cyphon/engines/elasticsearch/tests/test_engine.py
+++ b/cyphon/engines/elasticsearch/tests/test_engine.py
@@ -22,7 +22,10 @@
 import logging
 import time
 from unittest import skipIf
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from elasticsearch.exceptions import ConnectionError

--- a/cyphon/engines/mongodb/tests/test_engine.py
+++ b/cyphon/engines/mongodb/tests/test_engine.py
@@ -22,7 +22,10 @@ Tests the MongoDbEngine class.
 import logging
 import time
 from unittest import skipIf
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 import pymongo

--- a/cyphon/lab/geoip/test_geoip.py
+++ b/cyphon/lab/geoip/test_geoip.py
@@ -37,7 +37,6 @@ from lab.geoip import geoip
 _LOGGER = logging.getLogger(__name__)
 
 
-print(geoip.get_city_db_path())
 if os.path.isfile(geoip.get_city_db_path()):
     NOT_INSTALLED = False
 

--- a/cyphon/lab/geoip/test_geoip.py
+++ b/cyphon/lab/geoip/test_geoip.py
@@ -37,6 +37,7 @@ from lab.geoip import geoip
 _LOGGER = logging.getLogger(__name__)
 
 
+print(geoip.get_city_db_path())
 if os.path.isfile(geoip.get_city_db_path()):
     NOT_INSTALLED = False
 

--- a/cyphon/lab/geoip/test_geoip.py
+++ b/cyphon/lab/geoip/test_geoip.py
@@ -22,7 +22,10 @@
 import logging
 import os.path
 from unittest import TestCase, skipIf
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from geoip2.errors import AddressNotFoundError

--- a/cyphon/monitors/tests/test_models.py
+++ b/cyphon/monitors/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the Monitor class.
 
 # standard library
 from datetime import datetime
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 import logging
 
 # third party

--- a/cyphon/monitors/tests/test_views.py
+++ b/cyphon/monitors/tests/test_views.py
@@ -20,7 +20,10 @@ Tests views for Monitors.
 
 # standard library
 from collections import OrderedDict
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from rest_framework import status

--- a/cyphon/notifications/tests/test_signals.py
+++ b/cyphon/notifications/tests/test_signals.py
@@ -20,7 +20,10 @@ Tests for notification signals.
 
 # standard library
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/platforms/jira/tests/test_handlers.py
+++ b/cyphon/platforms/jira/tests/test_handlers.py
@@ -19,7 +19,10 @@ Tests the JiraHandler and IssueAPI classes.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.contrib.auth import get_user_model

--- a/cyphon/receiver/receiver.py
+++ b/cyphon/receiver/receiver.py
@@ -44,6 +44,7 @@ django.setup()
 
 # third party
 import pika
+import six
 
 # local
 from cyphon.documents import DocumentObj
@@ -73,6 +74,8 @@ def create_doc_obj(body):
     |DocumentObj|
 
     """
+    if isinstance(body, six.binary_type):
+        body = body.decode('utf-8')
     data = json.loads(body)
     doc_id = data.get('@uuid')
     data['_id'] = doc_id

--- a/cyphon/receiver/test_receiver.py
+++ b/cyphon/receiver/test_receiver.py
@@ -23,7 +23,10 @@ from collections import OrderedDict
 import copy
 import json
 import logging
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.test import TransactionTestCase

--- a/cyphon/responder/actions/tests/test_models.py
+++ b/cyphon/responder/actions/tests/test_models.py
@@ -19,7 +19,10 @@
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/responder/actions/tests/test_views.py
+++ b/cyphon/responder/actions/tests/test_views.py
@@ -19,7 +19,10 @@ Tests the Pipe class and the related RateLimit and SpecSheet classes.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from rest_framework import status

--- a/cyphon/responder/couriers/tests/test_models.py
+++ b/cyphon/responder/couriers/tests/test_models.py
@@ -19,7 +19,10 @@ Tests |Courier| model methods.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/datasifter/datachutes/tests/test_models.py
+++ b/cyphon/sifter/datasifter/datachutes/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the DataChute class.
 
 # standard library
 import logging
-from unittest.mock import call, Mock, patch
+try:
+    from unittest.mock import Mock, call, patch
+except ImportError:
+    from mock import Mock, call, patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/datasifter/datacondensers/tests/test_functional.py
+++ b/cyphon/sifter/datasifter/datacondensers/tests/test_functional.py
@@ -21,7 +21,10 @@ Functional tests for the DataCondenser app.
 # standard library
 import json
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.core.exceptions import ValidationError

--- a/cyphon/sifter/datasifter/datacondensers/tests/test_models.py
+++ b/cyphon/sifter/datasifter/datacondensers/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the Funnel class and related classes.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.contrib.contenttypes.models import ContentType

--- a/cyphon/sifter/datasifter/datamungers/tests/test_models.py
+++ b/cyphon/sifter/datasifter/datamungers/tests/test_models.py
@@ -57,5 +57,5 @@ class DataMungerTestCase(TestCase):
 
         datamunger.condenser.process.assert_called_once_with(data)
 
-        datamunger.distillery.save_data.assert_called_once()
+        assert datamunger.distillery.save_data.call_count == 1
         self.assertEqual(doc_id, mock_doc_id)

--- a/cyphon/sifter/datasifter/datamungers/tests/test_models.py
+++ b/cyphon/sifter/datasifter/datamungers/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the DataMunger class.
 """
 
 # standard library
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/logsifter/logchutes/tests/test_models.py
+++ b/cyphon/sifter/logsifter/logchutes/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the LogChute class.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/logsifter/logcondensers/tests/test_functional.py
+++ b/cyphon/sifter/logsifter/logcondensers/tests/test_functional.py
@@ -20,7 +20,10 @@ Functional tests for the LogCondenser app.
 
 # standard library
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.core.exceptions import ValidationError

--- a/cyphon/sifter/logsifter/logcondensers/tests/test_models.py
+++ b/cyphon/sifter/logsifter/logcondensers/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the LogChute class.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.contrib.contenttypes.models import ContentType

--- a/cyphon/sifter/mailsifter/mailchutes/tests/test_models.py
+++ b/cyphon/sifter/mailsifter/mailchutes/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the MailChute class.
 
 # standard library
 from email.mime.text import MIMEText
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.test import TestCase, TransactionTestCase

--- a/cyphon/sifter/mailsifter/mailchutes/tests/test_signals.py
+++ b/cyphon/sifter/mailsifter/mailchutes/tests/test_signals.py
@@ -45,4 +45,4 @@ class HandleMessageTestCase(TestCase):
                 as mock_process:
             message_received.send(sender='message_received',
                                   message=mock_message)
-            mock_process.assert_called_once()
+            assert mock_process.call_count == 1

--- a/cyphon/sifter/mailsifter/mailchutes/tests/test_signals.py
+++ b/cyphon/sifter/mailsifter/mailchutes/tests/test_signals.py
@@ -19,7 +19,10 @@ Tests signal recievers in the MailSifter package.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django_mailbox.signals import message_received

--- a/cyphon/sifter/mailsifter/mailcondensers/tests/test_functional.py
+++ b/cyphon/sifter/mailsifter/mailcondensers/tests/test_functional.py
@@ -20,7 +20,10 @@ Functional tests for the MailCondenser app.
 
 # standard library
 import logging
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from django.core.exceptions import ValidationError

--- a/cyphon/sifter/mailsifter/mailcondensers/tests/test_models.py
+++ b/cyphon/sifter/mailsifter/mailcondensers/tests/test_models.py
@@ -22,7 +22,10 @@
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from unittest import TestCase
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 import re
 
 # third party

--- a/cyphon/sifter/mailsifter/mailmungers/tests/test_models.py
+++ b/cyphon/sifter/mailsifter/mailmungers/tests/test_models.py
@@ -60,5 +60,5 @@ class MailMungerTestCase(TestCase):
             company=mailmunger.distillery.company
         )
 
-        mailmunger.distillery.save_data.assert_called_once()
+        assert mailmunger.distillery.save_data.call_count == 1
         self.assertEqual(doc_id, mock_doc_id)

--- a/cyphon/sifter/mailsifter/mailmungers/tests/test_models.py
+++ b/cyphon/sifter/mailsifter/mailmungers/tests/test_models.py
@@ -19,7 +19,10 @@
 """
 
 # standard library
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/mailsifter/tests/base.py
+++ b/cyphon/sifter/mailsifter/tests/base.py
@@ -24,7 +24,10 @@ from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import os
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.test import TestCase

--- a/cyphon/sifter/mailsifter/tests/test_accessors.py
+++ b/cyphon/sifter/mailsifter/tests/test_accessors.py
@@ -21,7 +21,10 @@ Tests accessor functions for the mailsifter package.
 # standard library
 from email.mime.multipart import MIMEMultipart
 import datetime
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 from testfixtures import LogCapture

--- a/cyphon/sifter/mailsifter/tests/test_attachments.py
+++ b/cyphon/sifter/mailsifter/tests/test_attachments.py
@@ -21,7 +21,10 @@ Tests the attchement helper functions of the mailsifter package.
 # standard library
 import datetime
 import os
-from unittest.mock import patch, Mock
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.conf import settings

--- a/cyphon/tests/functional_tests.py
+++ b/cyphon/tests/functional_tests.py
@@ -142,6 +142,7 @@ def _web_driver_available():
         return True
     except (ConnectionRefusedError, NameError, RuntimeError,
             WebDriverException) as error:
+        print(error)
         _LOGGER.warning('No WebDriver available for functional tests, '
                         'so those tests will be skipped.')
         return False

--- a/cyphon/tests/mock.py
+++ b/cyphon/tests/mock.py
@@ -20,7 +20,10 @@ Provides decorators for frequently used patches.
 """
 
 # standard library
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 DEFAULT = object()
 

--- a/cyphon/tests/test_fixture_manager.py
+++ b/cyphon/tests/test_fixture_manager.py
@@ -20,7 +20,10 @@ Tests the fixtures module.
 
 # standard library
 from unittest import TestCase
-from unittest.mock import patch
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
 
 # third party
 import six

--- a/cyphon/utils/dateutils/dateutils.py
+++ b/cyphon/utils/dateutils/dateutils.py
@@ -19,6 +19,7 @@ Utility functions for dates and times. Provides a suite of functions
 for manipulating dates and times. Defines a set of constants to be used for
 defining time units.
 """
+from __future__ import division
 
 # standard library
 import math
@@ -281,4 +282,3 @@ def date_from_str(date_string, date_format=None):
             LOGGER.error(fail_msg)
 
     return date
-

--- a/cyphon/utils/dbutils/tests/test_dbutils.py
+++ b/cyphon/utils/dbutils/tests/test_dbutils.py
@@ -20,7 +20,10 @@ Tests functions in the dbutils package.
 
 # standard library
 from unittest import TestCase
-from unittest.mock import patch, Mock
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # local
 from utils.dbutils import dbutils
@@ -31,7 +34,7 @@ class CountByGroupTestCase(TestCase):
     Tests the count_by_group function.
     """
 
-    @patch('django.db.models.query.QuerySet', autospec=True)        
+    @patch('django.db.models.query.QuerySet', autospec=True)
     def test_count_by_group(self, mock_queryset):
         """
         Tests the count_by_group function.

--- a/cyphon/utils/validators/tests/test_validators.py
+++ b/cyphon/utils/validators/tests/test_validators.py
@@ -23,7 +23,10 @@ within the MongoDb document prior to saving.
 # standard library
 from datetime import timedelta
 from unittest import TestCase
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
 from django.core.exceptions import ValidationError

--- a/cyphon/warehouses/tests/test_models.py
+++ b/cyphon/warehouses/tests/test_models.py
@@ -19,7 +19,10 @@ Tests the Warehouse class.
 """
 
 # standard library
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 # third party
 from django.conf import settings

--- a/cyphon/watchdogs/tests/test_models.py
+++ b/cyphon/watchdogs/tests/test_models.py
@@ -20,7 +20,10 @@ Tests the Watchdog and Triigger classes.
 
 # standard library
 import logging
-from unittest.mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 import threading
 
 # third party

--- a/cyphon/watchdogs/tests/test_signals.py
+++ b/cyphon/watchdogs/tests/test_signals.py
@@ -20,10 +20,13 @@ Tests signals in the Watchdog app.
 
 # standard library
 import logging
-from unittest.mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 # third party
-from django.test import TransactionTestCase 
+from django.test import TransactionTestCase
 
 # local
 from alerts.models import Alert

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,11 @@
 
 import sys
 import os
-from unittest.mock import MagicMock
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
 
 class Mock(MagicMock):
     @classmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ jira==1.0.10
 kombu==4.0.2
 langdetect==1.0.7
 maxminddb==1.3.0
+mock==2.0.0
 oauth2==1.9.0.post1
 oauthlib==2.0.2
 pika==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,6 @@ jira==1.0.10
 kombu==4.0.2
 langdetect==1.0.7
 maxminddb==1.3.0
-mock==2.0.0
 oauth2==1.9.0.post1
 oauthlib==2.0.2
 pika==0.10.0

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,10 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: Implementation :: CPython',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,36 @@
+[tox]
+envlist = py{27,34,35,36},py36-{functional,lint}
+
+[testenv]
+usedevelop = true
+changedir = cyphon
+commands =
+  rm -f __init__.py
+  coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
+basepython =
+  py27: python2.7
+  py34: python3.4
+  py35: python3.5
+  py36: python3.6
+deps =
+  codecov
+  -rrequirements.txt
+setenv =
+  COVERAGE_FILE = coverage.{envname}.xml
+whitelist_externals = rm
+alwayscopy = true
+
+[testenv:py36-functional]
+changedir = cyphon
+commands =
+  rm -f __init__.py
+  coverage run --source='.' manage.py test -p functionl_tests.py --noinput --keepdb
+whitelist_externals = rm
+alwayscopy = true
+
+[travis]
+python =
+  2.7: py27
+  3.4: py34
+  3.5: py35
+  3.6: py36, py36-functional, py36-lint

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ commands =
   # db connections are still open from threads in TransactionTestCases
   coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 basepython =
-  cov-{init,report}: python3.6
   py34: python3.4
   py35: python3.5
   py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,8 @@ setenv =
 
 [testenv:cov-report]
 commands =
-  coverage combine
-  coverage report -m
+  coverage combine -a
+  coverage report -m --skip-covered
   coverage xml -o {toxinidir}/coverage.xml
   coveralls
   codecov -f {toxinidir}/.coverage
@@ -52,11 +52,11 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' manage.py test -p test_functional.py --noinput --keepdb
+  coverage run -a --source='.' manage.py test -p test_functional.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =
-  COVERAGE_FILE = {toxinidir}/.coverage.functional.{envname}
+  COVERAGE_FILE = {toxinidir}/.coverage.{envname}
   FUNCTIONAL_TESTS_ENABLED = true
 passenv = DISPLAY FUNCTIONAL_* SAUCE_* TRAVIS_*
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
   mock
   -rrequirements.txt
 setenv =
-  COVERAGE_FILE = .coverage.{envname}
+  COVERAGE_FILE = {toxinidir}/.coverage.{envname}
   FUNCTIONAL_TESTS_ENABLED = false
 whitelist_externals = rm
 alwayscopy = true
@@ -28,15 +28,22 @@ passenv = GEOIP_PATH
 
 [testenv:cov-init]
 commands = coverage erase
+deps = coverage
+setenv =
+  COVERAGE_FILE = {toxinidir}/.coverage
 
 [testenv:cov-report]
 commands =
   coverage combine
   coverage report -m
-  coveralls
-  codecov -f .coverage
-  python-codacy-coverage -r .coverage
+
+setenv =
+  COVERAGE_FILE = {toxinidir}/.coverage
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+deps =
+  codacy-coverage
+  codecov
+  coveralls
 
 [testenv:py36-functional]
 changedir = cyphon

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,11 @@ commands =
   # db connections are still open from threads in TransactionTestCases
   coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 basepython =
+  cov-init: python3.4
   py34: python3.4
   py35: python3.5
   py36: python3.6
+  cov-report: python3.6
 deps =
   codecov
   mock

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' manage.py test -p functionl_tests.py --noinput --keepdb
+  coverage run --source='.' manage.py test -p functional_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -36,9 +36,10 @@ setenv =
 commands =
   coverage combine
   coverage report -m
+  coverage xml -o {toxinidir}/coverage.xml
   coveralls
   codecov -f {toxinidir}/.coverage
-  python-codacy-coverage -r {toxinidir}/.coverage
+  python-codacy-coverage -r {toxinidir}/coverage.xml
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage
 passenv = CODACY_PROJECT_TOKEN TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,8 @@ commands =
   coverage combine
   coverage report -m
   coveralls
-  codecov -f .coverage
-  python-codacy-coverage -r .coverage
+  codecov -f {toxinidir}/.coverage
+  python-codacy-coverage -r {toxinidir}/.coverage
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage
 passenv = CODACY_PROJECT_TOKEN TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init,py{34,35,36},py36-{functional,lint},cov-report
+envlist = cov-init, py{34,35,36}, py36-{functional,lint}, cov-report
 
 [testenv]
 usedevelop = true
@@ -48,6 +48,6 @@ setenv =
 
 [travis]
 python =
-  3.4: py34
+  3.4: cov-init, py34
   3.5: py35
-  3.6: cov-init, cov-report, py36, py36-functional, py36-lint
+  3.6: py36, py36-functional, py36-lint, cov-report

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' python manage.py test -p functionl_tests.py --noinput --keepdb
+  coverage run --source='.' manage.py test -p functionl_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
   rm -f __init__.py
   # use --keepdb to avoid OperationalError during teardown in case any
   # db connections are still open from threads in TransactionTestCases
-  coverage run --source='.' --omit=*migrations*,*test*,*functional* manage.py test --noinput --keepdb
+  coverage run --rcfile={toxinidir}/.coveragerc manage.py test --noinput --keepdb
 basepython =
   cov-init: python3.4
   py34: python3.4
@@ -34,7 +34,7 @@ setenv =
 
 [testenv:cov-report]
 commands =
-  coverage combine -a
+  coverage combine
   coverage report -m --skip-covered
   coverage xml -o {toxinidir}/coverage.xml
   coveralls
@@ -52,7 +52,7 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run -a --source='.' manage.py test -p test_functional.py --noinput --keepdb
+  coverage run --rcfile={toxinidir}/.coveragerc manage.py test -p test_functional.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py{34,35,36}, py36-lint, cov-report
+envlist = cov-init, py{34,35,36}, py36-{functional,lint}, cov-report
 
 [testenv]
 usedevelop = true
@@ -48,20 +48,20 @@ deps =
   codecov
   coveralls
 
-[testenv:py36]
+[testenv:py36-functional]
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' manage.py test --noinput --keepdb
+  coverage run --source='.' manage.py test -p test_functional.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage.{envname}
   FUNCTIONAL_TESTS_ENABLED = true
-passenv = FUNCTIONAL_* SAUCE_*
+passenv = DISPLAY FUNCTIONAL_* SAUCE_*
 
 [travis]
 python =
   3.4: cov-init, py34
   3.5: py35
-  3.6: py36, py36-lint, cov-report
+  3.6: py36, py36-functional, py36-lint, cov-report

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
   coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 basepython =
   cov-{init,report}: python3.6
-  py27: python2.7
+  ; py27: python2.7
   py34: python3.4
   py35: python3.5
   py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -52,10 +52,11 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  python manage.py test -p functionl_tests.py --noinput --keepdb
+  coverage run --source='.' python manage.py test -p functionl_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =
+  COVERAGE_FILE = {toxinidir}/.coverage.{envname}
   FUNCTIONAL_TESTS_ENABLED = true
 passenv = FUNCTIONAL_* SAUCE_*
 

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ commands =
   coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 basepython =
   cov-{init,report}: python3.6
-  ; py27: python2.7
   py34: python3.4
   py35: python3.5
   py36: python3.6
@@ -49,7 +48,6 @@ setenv =
 
 [travis]
 python =
-  ; 2.7: py27
   3.4: py34
   3.5: py35
   3.6: cov-init, cov-report, py36, py36-functional, py36-lint

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
   rm -f __init__.py
   # use --keepdb to avoid OperationalError during teardown in case any
   # db connections are still open from threads in TransactionTestCases
-  coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
+  coverage run --source='.' --omit=*migrations*,*test*,*functional* manage.py test --noinput --keepdb
 basepython =
   cov-init: python3.4
   py34: python3.4
@@ -56,7 +56,7 @@ commands =
 whitelist_externals = rm
 alwayscopy = true
 setenv =
-  COVERAGE_FILE = {toxinidir}/.coverage.{envname}
+  COVERAGE_FILE = {toxinidir}/.coverage.functional.{envname}
   FUNCTIONAL_TESTS_ENABLED = true
 passenv = DISPLAY FUNCTIONAL_* SAUCE_* TRAVIS_*
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,9 @@ setenv =
 commands =
   coverage combine
   coverage report -m
-
+  coveralls
+  codecov -f .coverage
+  python-codacy-coverage -r .coverage
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
   python-codacy-coverage -r {toxinidir}/coverage.xml
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage
-passenv = CODACY_PROJECT_TOKEN TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = CI CODACY_PROJECT_TOKEN TRAVIS*
 deps =
   codacy-coverage
   codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,16 @@
 [tox]
-envlist = py{27,34,35,36},py36-{functional,lint}
+envlist = cov-init,py{27,34,35,36},py36-{functional,lint},cov-report
 
 [testenv]
 usedevelop = true
 changedir = cyphon
 commands =
   rm -f __init__.py
+  # use --keepdb to avoid OperationalError during teardown in case any
+  # db connections are still open from threads in TransactionTestCases
   coverage run --source='.' --omit=*migrations*,*test* manage.py test --noinput --keepdb
 basepython =
+  cov-{init,report}: python3.6
   py27: python2.7
   py34: python3.4
   py35: python3.5
@@ -16,9 +19,21 @@ deps =
   codecov
   -rrequirements.txt
 setenv =
-  COVERAGE_FILE = coverage.{envname}.xml
+  COVERAGE_FILE = .coverage.{envname}
 whitelist_externals = rm
 alwayscopy = true
+
+[testenv:cov-init]
+commands = coverage erase
+setenv =
+  COVERAGE_FILE = .coverage
+
+[testenv:cov-report]
+commands =
+  coverage combine
+  coverage report -m
+setenv =
+  COVERAGE_FILE = .coverage
 
 [testenv:py36-functional]
 changedir = cyphon
@@ -33,4 +48,4 @@ python =
   2.7: py27
   3.4: py34
   3.5: py35
-  3.6: py36, py36-functional, py36-lint
+  3.6: cov-init, cov-report, py36, py36-functional, py36-lint

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init,py{27,34,35,36},py36-{functional,lint},cov-report
+envlist = cov-init,py{34,35,36},py36-{functional,lint},cov-report
 
 [testenv]
 usedevelop = true
@@ -17,9 +17,11 @@ basepython =
   py36: python3.6
 deps =
   codecov
+  mock
   -rrequirements.txt
 setenv =
   COVERAGE_FILE = .coverage.{envname}
+  FUNCTIONAL_TESTS_ENABLED = false
 whitelist_externals = rm
 alwayscopy = true
 
@@ -42,10 +44,12 @@ commands =
   coverage run --source='.' manage.py test -p functionl_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
+setenv =
+  FUNCTIONAL_TESTS_ENABLED = true
 
 [travis]
 python =
-  2.7: py27
+  ; 2.7: py27
   3.4: py34
   3.5: py35
   3.6: cov-init, cov-report, py36, py36-functional, py36-lint

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 changedir = cyphon
 commands =
   rm -f __init__.py
-  manage.py test -p functionl_tests.py --noinput --keepdb
+  python manage.py test -p functionl_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
   python-codacy-coverage -r .coverage
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage
-passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
+passenv = CODACY_PROJECT_TOKEN TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
   codacy-coverage
   codecov
@@ -56,6 +56,7 @@ whitelist_externals = rm
 alwayscopy = true
 setenv =
   FUNCTIONAL_TESTS_ENABLED = true
+passenv = FUNCTIONAL_* SAUCE_*
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ setenv =
 [testenv:cov-report]
 commands =
   coverage combine
-  coverage report -m --skip-covered
+  coverage report -m
   coverage xml -o {toxinidir}/coverage.xml
   coveralls
   codecov -f {toxinidir}/.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ alwayscopy = true
 setenv =
   COVERAGE_FILE = {toxinidir}/.coverage.{envname}
   FUNCTIONAL_TESTS_ENABLED = true
-passenv = DISPLAY FUNCTIONAL_* SAUCE_*
+passenv = DISPLAY FUNCTIONAL_* SAUCE_* TRAVIS_*
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -27,21 +27,21 @@ alwayscopy = true
 
 [testenv:cov-init]
 commands = coverage erase
-setenv =
-  COVERAGE_FILE = .coverage
 
 [testenv:cov-report]
 commands =
   coverage combine
   coverage report -m
-setenv =
-  COVERAGE_FILE = .coverage
+  coveralls
+  codecov -f .coverage
+  python-codacy-coverage -r .coverage
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 
 [testenv:py36-functional]
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' manage.py test -p functionl_tests.py --noinput --keepdb
+  manage.py test -p functionl_tests.py --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ setenv =
   FUNCTIONAL_TESTS_ENABLED = false
 whitelist_externals = rm
 alwayscopy = true
+passenv = GEOIP_PATH
 
 [testenv:cov-init]
 commands = coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py{34,35,36}, py36-{functional,lint}, cov-report
+envlist = cov-init, py{34,35,36}, py36-functional, cov-report
 
 [testenv]
 usedevelop = true
@@ -64,4 +64,4 @@ passenv = DISPLAY FUNCTIONAL_* SAUCE_* TRAVIS_*
 python =
   3.4: cov-init, py34
   3.5: py35
-  3.6: py36, py36-functional, py36-lint, cov-report
+  3.6: py36, py36-functional, cov-report

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py{34,35,36}, py36-{functional,lint}, cov-report
+envlist = cov-init, py{34,35,36}, py36-lint, cov-report
 
 [testenv]
 usedevelop = true
@@ -48,11 +48,11 @@ deps =
   codecov
   coveralls
 
-[testenv:py36-functional]
+[testenv:py36]
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --source='.' manage.py test -p functional_tests.py --noinput --keepdb
+  coverage run --source='.' manage.py test --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =
@@ -64,4 +64,4 @@ passenv = FUNCTIONAL_* SAUCE_*
 python =
   3.4: cov-init, py34
   3.5: py35
-  3.6: py36, py36-functional, py36-lint, cov-report
+  3.6: py36, py36-lint, cov-report


### PR DESCRIPTION
* Added 3.4, 3.5, and 3.6 environments. Recent versions of Django do not support 3.1 - 3.3, and there are way too many Cyphon test failures unde 2.7 to warrant enabling that right now.
* Added separate environments for linting (py36-lint), which can be used to setup flake8, pep8, and/or any other static code analysis tools in the future.
* Code coverage is run in a separate environment, and collected (using ``coverage combine``) from all the test environments. This may impact the coverage slightly.
* Added .coveragerc file with some defaults.
* Changed the way the GeoIP database is copied to the Travis environment, by changing the ``docker exec cp`` to the shared volume to instead be a ``sudo docker cp``. Unsure why the former wasn't working anymore when running tox.
* Using [tox-travis](https://tox-travis.readthedocs.io/en/stable/) to configure the interpreters used for the tox environments.
* Updated all the unit tests that use mock to fallback to the backport of mock, only applies to Python 2.7 but might be useful in the future.
* Fixed a few (failing under <3.6) unit tests that were calling ``assert_called_once``, they should do something like ``assert x.call_count == 1`` instead. See http://engineroom.trackmaven.com/blog/mocking-mistakes/
* Fixed the QueryFieldset class's dunder string method to use an OrderedDict for rendering class properties as a dictionary representation, fixing some of the unit tests that would fail randomly.