### PR TITLE
updated Django to 1.11.2, and pinned DAL to 2.3.3

### DIFF
--- a/cyphon/bottler/tastes/forms.py
+++ b/cyphon/bottler/tastes/forms.py
@@ -20,11 +20,9 @@ Defines forms for Tastes.
 
 # third party
 from autocomplete_light import forms as auto_forms
-from autocomplete_light.widgets import ChoiceWidget
-# from autocomplete_light.widgets import ChoiceWidget
 
 # local
-from cyphon.autocomplete import AutoCompleteModelFormMixin
+from cyphon.autocomplete import AutoCompleteModelFormMixin, ChoiceWidget
 from .models import Taste
 
 

--- a/cyphon/contexts/forms.py
+++ b/cyphon/contexts/forms.py
@@ -20,11 +20,10 @@ Defines forms for ContextFilters.
 
 # third party
 from autocomplete_light import forms as auto_forms
-from autocomplete_light import widgets as auto_widgets
 
 # local
 from cyphon.choices import OPERATOR_CHOICES
-from cyphon.autocomplete import AutoCompleteModelFormMixin
+from cyphon.autocomplete import AutoCompleteModelFormMixin, ChoiceWidget
 from .models import ContextFilter
 
 
@@ -50,9 +49,9 @@ class ContextFilterForm(auto_forms.ModelForm, AutoCompleteModelFormMixin):
         model = ContextFilter
         fields = ['context', 'search_field', 'operator', 'value_field']  # reorder
         widgets = {
-            'search_field': auto_widgets.ChoiceWidget('FilterSearchFieldsByContext'),
-            'operator': auto_widgets.ChoiceWidget('FilterOperatorsBySearchField'),
-            'value_field': auto_widgets.ChoiceWidget('FilterValueFieldsByContext'),
+            'search_field': ChoiceWidget('FilterSearchFieldsByContext'),
+            'operator': ChoiceWidget('FilterOperatorsBySearchField'),
+            'value_field': ChoiceWidget('FilterValueFieldsByContext'),
         }
 
 
@@ -78,8 +77,8 @@ class ContextFilterInlineForm(auto_forms.ModelForm, AutoCompleteModelFormMixin):
         model = ContextFilter
         fields = ['context', 'search_field', 'operator', 'value_field']  # reorder
         widgets = {
-            'search_field': auto_widgets.ChoiceWidget('FilterSearchFieldsByRelatedDistillery'),
-            'operator': auto_widgets.ChoiceWidget('FilterOperatorsBySearchField'),
-            'value_field': auto_widgets.ChoiceWidget('FilterValueFieldsByFocalDistillery'),
+            'search_field': ChoiceWidget('FilterSearchFieldsByRelatedDistillery'),
+            'operator': ChoiceWidget('FilterOperatorsBySearchField'),
+            'value_field': ChoiceWidget('FilterValueFieldsByFocalDistillery'),
         }
 

--- a/cyphon/cyphon/autocomplete.py
+++ b/cyphon/cyphon/autocomplete.py
@@ -19,10 +19,18 @@
 """
 
 # third party
-from autocomplete_light.widgets import ChoiceWidget
+from autocomplete_light.widgets import ChoiceWidget as _ChoiceWidget
 
 # local
 from utils.choices.choices import get_choice_by_value
+
+
+class ChoiceWidget(_ChoiceWidget):
+
+    def build_attrs(self, extra_attrs=None, autocomplete=None, **kwargs):
+        extra_attrs.update(getattr(autocomplete, 'attrs', {}))
+        return super(ChoiceWidget, self).build_attrs(
+            extra_attrs, autocomplete, **kwargs)
 
 
 class AutoCompleteModelFormMixin(object):

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -55,7 +55,7 @@ class RequireLockTest(TestCase):
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
         mock_cursor = Mock()
-        mock_cursor.__enter__ = Mock(return_value=(Mock(), None))
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
         mock_cursor.execute = Mock()
 

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -55,6 +55,8 @@ class RequireLockTest(TestCase):
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
         mock_cursor = Mock()
+        mock_cursor.__enter__ = Mock(return_value=(Mock(), None))
+        mock_cursor.__exit__ = Mock(return_value=None)
         mock_cursor.execute = Mock()
 
         with patch('cyphon.transaction.db.connection.cursor',

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -21,9 +21,9 @@ Tests for the locking database tables.
 # standard library
 from unittest import TestCase
 try:
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import MagicMock, Mock, patch
 except ImportError:
-    from mock import MagicMock, patch
+    from mock import MagicMock, Mock, patch
 
 # third party
 from django.db import transaction

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -55,10 +55,6 @@ class RequireLockTest(TestCase):
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
         mock_cursor = MagicMock()
-        mock_cursor.__iter__.return_value = []
-        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
-        mock_cursor.__exit__ = Mock(return_value=[])
-        mock_cursor.execute = Mock()
 
         with patch('cyphon.transaction.db.connection.cursor',
                    return_value=mock_cursor):

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -55,6 +55,7 @@ class RequireLockTest(TestCase):
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
         mock_cursor = Mock()
+        mock_cursor.return_value = []
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=[])
         mock_cursor.execute = Mock()

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 try:
     from unittest.mock import Mock, patch
 except ImportError:
-    from mock import Mock, patch
+    from mock import MagicMock, patch
 
 # third party
 from django.db import transaction
@@ -54,7 +54,7 @@ class RequireLockTest(TestCase):
 
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
-        mock_cursor = Mock()
+        mock_cursor = MagicMock()
         mock_cursor.__iter__.return_value = []
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=[])

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -21,7 +21,7 @@ Tests for the locking database tables.
 # standard library
 from unittest import TestCase
 try:
-    from unittest.mock import Mock, patch
+    from unittest.mock import MagicMock, patch
 except ImportError:
     from mock import MagicMock, patch
 

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -56,7 +56,7 @@ class RequireLockTest(TestCase):
 
         mock_cursor = Mock()
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
-        mock_cursor.__exit__ = Mock(return_value=None)
+        mock_cursor.__exit__ = Mock(return_value=[])
         mock_cursor.execute = Mock()
 
         with patch('cyphon.transaction.db.connection.cursor',

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -21,9 +21,9 @@ Tests for the locking database tables.
 # standard library
 from unittest import TestCase
 try:
-    from unittest.mock import MagicMock, Mock, patch
+    from unittest.mock import MagicMock, patch
 except ImportError:
-    from mock import MagicMock, Mock, patch
+    from mock import MagicMock, patch
 
 # third party
 from django.db import transaction

--- a/cyphon/cyphon/tests/test_transaction.py
+++ b/cyphon/cyphon/tests/test_transaction.py
@@ -55,7 +55,7 @@ class RequireLockTest(TestCase):
         command = 'LOCK TABLE %s IN %s MODE' % (self.model._meta.db_table, lock)
 
         mock_cursor = Mock()
-        mock_cursor.return_value = []
+        mock_cursor.__iter__.return_value = []
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=[])
         mock_cursor.execute = Mock()

--- a/cyphon/sifter/datasifter/datacondensers/forms.py
+++ b/cyphon/sifter/datasifter/datacondensers/forms.py
@@ -22,6 +22,7 @@ Defines forms for DataFittings and DataCondensers.
 import autocomplete_light
 
 # local
+from cyphon.autocomplete import AutoCompleteModelFormMixin, ChoiceWidget
 from sifter.condensers.forms import (
     CondenserForm,
     FittingForm,
@@ -62,9 +63,12 @@ class DataFittingForm(FittingForm):
         autocomplete_names = {
             'target_field': 'FilterTargetFieldsByDataCondenser'
         }
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByDataCondenser'),
+        }
 
 
-class DataFittingInlineForm(FittingInlineForm):
+class DataFittingInlineForm(FittingInlineForm, AutoCompleteModelFormMixin):
     """
     Defines an inline form for adding or updating a DataFitting using
     autocomplete fields.
@@ -72,4 +76,6 @@ class DataFittingInlineForm(FittingInlineForm):
 
     class Meta(FittingInlineForm.Meta):
         model = DataFitting
-
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByBottle'),
+        }

--- a/cyphon/sifter/logsifter/logcondensers/forms.py
+++ b/cyphon/sifter/logsifter/logcondensers/forms.py
@@ -22,6 +22,7 @@ Defines forms for LogFittings and LogCondensers.
 import autocomplete_light
 
 # local
+from cyphon.autocomplete import AutoCompleteModelFormMixin, ChoiceWidget
 from sifter.condensers.forms import (
     CondenserForm,
     FittingForm,
@@ -51,7 +52,7 @@ class LogCondenserForm(CondenserForm):
         model = LogCondenser
 
 
-class LogFittingForm(FittingForm):
+class LogFittingForm(FittingForm, AutoCompleteModelFormMixin):
     """
     Defines a form for adding or updating a LogaFitting using autocomplete
     fields.
@@ -62,9 +63,12 @@ class LogFittingForm(FittingForm):
         autocomplete_names = {
             'target_field': 'FilterTargetFieldsByLogCondenser'
         }
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByLogCondenser'),
+        }
 
 
-class LogFittingInlineForm(FittingInlineForm):
+class LogFittingInlineForm(FittingInlineForm, AutoCompleteModelFormMixin):
     """
     Defines an inline form for adding or updating a LogFitting using
     autocomplete fields.
@@ -72,4 +76,7 @@ class LogFittingInlineForm(FittingInlineForm):
 
     class Meta(FittingInlineForm.Meta):
         model = LogFitting
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByBottle'),
+        }
 

--- a/cyphon/sifter/mailsifter/mailcondensers/forms.py
+++ b/cyphon/sifter/mailsifter/mailcondensers/forms.py
@@ -22,6 +22,7 @@ Defines forms for MailFittings and MailCondensers.
 import autocomplete_light
 
 # local
+from cyphon.autocomplete import AutoCompleteModelFormMixin, ChoiceWidget
 from sifter.condensers.forms import (
     CondenserForm,
     FittingForm,
@@ -51,7 +52,7 @@ class MailCondenserForm(CondenserForm):
         model = MailCondenser
 
 
-class MailFittingForm(FittingForm):
+class MailFittingForm(FittingForm, AutoCompleteModelFormMixin):
     """
     Defines a form for adding or updating a MailFitting using autocomplete
     fields.
@@ -61,6 +62,9 @@ class MailFittingForm(FittingForm):
         model = MailFitting
         autocomplete_names = {
             'target_field': 'FilterTargetFieldsByMailCondenser'
+        }
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByMailCondenser'),
         }
 
 

--- a/cyphon/sifter/mailsifter/mailcondensers/forms.py
+++ b/cyphon/sifter/mailsifter/mailcondensers/forms.py
@@ -76,4 +76,6 @@ class MailFittingInlineForm(FittingInlineForm):
 
     class Meta(FittingInlineForm.Meta):
         model = MailFitting
-
+        widgets = {
+            'target_field': ChoiceWidget('FilterTargetFieldsByBottle'),
+        }

--- a/cyphon/tests/pages/element.py
+++ b/cyphon/tests/pages/element.py
@@ -149,6 +149,7 @@ class AutocompleteElement(HtmlElement):
         super(AutocompleteElement, self).__init__(*args, **kwargs)
         self.driver = driver
         self.path = '//span[@data-input-id="id_%s-autocomplete"]' % self.locator
+        print(self.path)
         self.name = self.locator + '-autocomplete'
 
     def click(self):

--- a/cyphon/tests/pages/element.py
+++ b/cyphon/tests/pages/element.py
@@ -149,7 +149,6 @@ class AutocompleteElement(HtmlElement):
         super(AutocompleteElement, self).__init__(*args, **kwargs)
         self.driver = driver
         self.path = '//span[@data-input-id="id_%s-autocomplete"]' % self.locator
-        print(self.path)
         self.name = self.locator + '-autocomplete'
 
     def click(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ billiard==3.5.0.2
 bleach==2.0.0
 celery==4.0.2
 cryptography==1.9
-Django==1.10.7
-django-autocomplete-light>=2.0.0,<3.0.0
+Django==1.11.2
+django-autocomplete-light==2.3.3  # pyup: >=2.0.0,<3.0.0
 django-constance==2.0.0
 django-cors-headers==2.1.0
 django-extensions==1.7.9

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ deps =
 changedir = cyphon
 commands =
   rm -f __init__.py
-  coverage run --rcfile={toxinidir}/.coveragerc manage.py test -p test_functional.py --noinput --keepdb
+  coverage run --rcfile={toxinidir}/.coveragerc manage.py test -p test_functional.py {posargs} --noinput --keepdb
 whitelist_externals = rm
 alwayscopy = true
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
   rm -f __init__.py
   # use --keepdb to avoid OperationalError during teardown in case any
   # db connections are still open from threads in TransactionTestCases
-  coverage run --rcfile={toxinidir}/.coveragerc manage.py test --noinput --keepdb
+  coverage run --rcfile={toxinidir}/.coveragerc manage.py test {posargs} --noinput --keepdb
 basepython =
   cov-init: python3.4
   py34: python3.4


### PR DESCRIPTION
DAL 3.x is currently broken when used with Grappelli, and the only workarounds appear to be modifying the vendor js for select2 in DAL, which is probably not ideal. DAL 2.x is still considered stable, so I added a comment directive for pyup to ignore 3.x for now. 

Built an image using these constraints and tested that DAL functions as expected in Django 1.11.2.