### PR TITLE
Actually fix libproj

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,12 @@ COPY requirements.txt $CYPHON_HOME/requirements.txt
 RUN apk add -U --repository http://dl-5.alpinelinux.org/alpine/edge/testing/ \
       binutils \
       gdal \
-      py-gdal \
       postgis \
+      proj4-dev \
+      py-gdal \
       su-exec \
  && ln -s /usr/lib/libgdal.so.20 /usr/lib/libgdal.so \
  && ln -s /usr/lib/libgeos_c.so.1 /usr/lib/libgeos_c.so \
- && ln -s /usr/lib/libproj.so.12 /usr/lib/libproj.so \
  && apk add -U \
       --repository http://dl-5.alpinelinux.org/alpine/edge/testing/ \
       -t build-deps \
@@ -54,7 +54,6 @@ RUN apk add -U --repository http://dl-5.alpinelinux.org/alpine/edge/testing/ \
       postgis \
       postgresql-dev \
       python3-dev \
-      proj4-dev \
  && pip install -r $CYPHON_HOME/requirements.txt \
  && apk del build-deps
 


### PR DESCRIPTION
The previous PR from a branch of the same name didn't actually fix the segfaulting issue, because the symlink was created before proj4-dev was ever installed - yes, that's right, ``proj4-dev`` is what includes libproj.so, not proj4, in the Alpine packages. So the fix is to install ``proj4-dev`` and leave it, rather than removing it as part of the ``build-base`` virtual group. (See https://pkgs.alpinelinux.org/contents?branch=edge&name=proj4-dev&arch=x86_64&repo=testing)

Built and verified that ``/usr/lib/libproj.so`` exist.