### PR TITLE
Fix Sphinx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ addons:
   sauce_connect: true
 
 python:
+  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,16 +24,32 @@ except ImportError:
 
 
 class Mock(MagicMock):
+
     @classmethod
     def __getattr__(cls, name):
+        if name == 'default_app_config':
+            raise AttributeError()
         return MagicMock()
 
+
+def make_mock(mod_name, *args, **kwargs):
+    mock = Mock(*args, **kwargs)
+    mock.__name__ = ''
+    mock.__path__ = []
+    mock.__file__ = ''
+    return mock
+
+
 MOCK_MODULES = [
-    'django.contrib.gis.gdal',
+    'django.contrib.gis',
+    'django.contrib.gis.db',
+    'django.contrib.gis.db.models',
+    'django.contrib.gis.geos',
     'elasticsearch',
 ]
 
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
+sys.modules.update((mod_name, make_mock(mod_name)) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -43,6 +59,10 @@ sys.path.insert(0, os.path.abspath('../../cyphon'))
 os.environ['DJANGO_SETTINGS_MODULE'] = 'cyphon.settings.sphinx'
 import django
 django.setup()
+
+
+import target.locations.models
+target.locations.models.Location.objects = MagicMock()
 
 # sys.path.insert(0, os.path.abspath('..'))
 # from django.conf import settings

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = cov-init, py{34,35,36}, py36-functional, cov-report
+envlist = cov-init, py27-docs, py{34,35,36}, py36-functional, cov-report
 
 [testenv]
 usedevelop = true
@@ -11,6 +11,7 @@ commands =
   coverage run --rcfile={toxinidir}/.coveragerc manage.py test {posargs} --noinput --keepdb
 basepython =
   cov-init: python3.4
+  py27-docs: python2.7
   py34: python3.4
   py35: python3.5
   py36: python3.6
@@ -48,6 +49,11 @@ deps =
   codecov
   coveralls
 
+[testenv:py27-docs]
+commands =
+  pip install sphinx sphinx_rtd_theme
+  sphinx-build -b html -d {envtmpdir}/doctrees {toxinidir}/docs/source {envtmpdir}/html
+
 [testenv:py36-functional]
 changedir = cyphon
 commands =
@@ -62,6 +68,7 @@ passenv = DISPLAY FUNCTIONAL_* SAUCE_* TRAVIS_*
 
 [travis]
 python =
+  2.7: py27-docs
   3.4: cov-init, py34
   3.5: py35
   3.6: py36, py36-functional, cov-report


### PR DESCRIPTION
Upgrading to Django 1.11 broke the Sphinx build on systems that don't have GDAL installed (like RTD), this branch works around that by mocking the Django GIS libraries and patching various things that are in the call path that break when building docs.