### PR TITLE
Prevent recursive sieves

### DIFF
--- a/cyphon/sifter/datasifter/datasieves/tests/test_models.py
+++ b/cyphon/sifter/datasifter/datasieves/tests/test_models.py
@@ -19,10 +19,15 @@ Tests the DataSieve class and related classes.
 """
 
 # third party
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 # local
-from sifter.datasifter.datasieves.models import DataSieve
+from sifter.datasifter.datasieves.models import (
+    DataRule,
+    DataSieve,
+    DataSieveNode,
+)
 from tests.fixture_manager import get_fixtures
 
 
@@ -82,3 +87,57 @@ class DataSieveTestCase(TestCase):
         self.datasieve.negate = True
         data = {'subject': 'this is a critical alert'}
         self.assertFalse(self.datasieve.is_match(data))
+
+
+class DataSieveNodeTestCase(TestCase):
+    """
+    Tests the DataSieve class.
+    """
+    fixtures = get_fixtures(['datasieves'])
+
+    def test_valid_rule(self):
+        """
+        Tests the clean() method when the SieveNode refers to a Rule.
+        """
+        sieve_1 = DataSieve.objects.get(pk=1)
+        rule_2 = DataRule.objects.get(pk=2)
+        node = DataSieveNode(sieve=sieve_1, node_object=rule_2)
+        try:
+            node.clean()
+        except ValidationError:
+            self.fail('DataSieveNode raised ValidationError unexpectedly')
+
+    def test_valid_sieve(self):
+        """
+        Tests the clean() method when the SieveNode refers to a Sieve
+        that doesn't contain its parent Sieve.
+        """
+        sieve_1 = DataSieve.objects.get(pk=1)
+        sieve_2 = DataSieve.objects.get(pk=2)
+        node = DataSieveNode(sieve=sieve_1, node_object=sieve_2)
+        try:
+            node.clean()
+        except ValidationError:
+            self.fail('DataSieveNode raised ValidationError unexpectedly')
+
+    def test_invalid_direct_sieve(self):
+        """
+        Tests the clean() method when the SieveNode refers to a Sieve
+        that's the same as its parent Sieve.
+        """
+        sieve_1 = DataSieve.objects.get(pk=1)
+        node = DataSieveNode(sieve=sieve_1, node_object=sieve_1)
+        with self.assertRaises(ValidationError):
+            node.clean()
+
+    def test_invalid_indirect_sieve(self):
+        """
+        Tests the clean() method when the SieveNode refers to a Sieve
+        that contains its parent Sieve.
+        """
+        sieve_1 = DataSieve.objects.get(pk=1)
+        sieve_2 = DataSieve.objects.get(pk=2)
+        DataSieveNode.objects.create(sieve=sieve_2, node_object=sieve_1)
+        node = DataSieveNode(sieve=sieve_1, node_object=sieve_2)
+        with self.assertRaises(ValidationError):
+            node.clean()

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ django-grappelli==2.10.1
 django-mailbox==4.5.4
 django-picklefield==1.0.0
 django-s3-storage==0.12.0
-Django==1.11.4
+Django==1.11.5
 djangorestframework-jwt==1.11.0
 djangorestframework==3.6.4
 docutils==0.14
@@ -41,7 +41,7 @@ oauthlib==2.0.2
 pika==0.11.0
 Pillow==4.2.1
 psycopg2==2.7.3.1
-PyJWT==1.5.2
+PyJWT==1.5.3
 pymongo==3.5.1
 python-dateutil==2.6.1
 pytz==2017.2
@@ -51,7 +51,7 @@ requests==2.18.4
 sauceclient==1.0.0
 selenium==3.5.0
 six==1.10.0
-testfixtures==5.1.1
+testfixtures==5.2.0
 textblob==0.13.0
 tlslite==0.4.9
 tweepy==3.5.0


### PR DESCRIPTION
Validates SieveNodes so they can't point to Sieves that contain their parent Sieves, which would create an endless loop when `SieveNode.is_match()` is called.