### PR TITLE
Bugfix for Context keyword search

### DIFF
--- a/cyphon/engines/elasticsearch/queries.py
+++ b/cyphon/engines/elasticsearch/queries.py
@@ -41,6 +41,7 @@ Function                              Description
 
 # standard library
 import json
+import re
 
 # local
 from engines.queries import EngineQuery, EngineQueryFieldset
@@ -74,7 +75,8 @@ def regex_query(field_name, value):
         An Elasticsearch regexp query.
 
     """
-    return {'regexp': {field_name: '.*"%s".*' % value}}
+    value = re.escape(value)
+    return {'regexp': {field_name: '.*%s.*' % value}}
 
 
 def bool_query(must=None, should=None, must_not=None, filter_expr=None):

--- a/cyphon/engines/tests/mixins.py
+++ b/cyphon/engines/tests/mixins.py
@@ -489,6 +489,25 @@ class FilterTestCaseMixin(object):
         self.assertIn(self._get_doc(docs, 0)['user']['screen_name'], expected_names)
         self.assertIn(self._get_doc(docs, 1)['user']['screen_name'], expected_names)
 
+    def test_regex_unmatched_quote(self):
+        """
+        Tests the find method for a 'regex' filter with a string
+        containing an unmatched quotation mark.
+        """
+        fieldsets = [
+            QueryFieldset(
+                field_name='user.screen_name',
+                field_type='CharField',
+                operator='regex',
+                value='"john'
+            )
+        ]
+
+        query = EngineQuery(fieldsets, 'AND')
+        results = self.engine.find(query)
+        count = results['count']
+        self.assertEqual(count, 0)
+
     def test_not_regex_with_fragment(self):
         """
         Tests the find method for a 'not:regex' filter with a word fragment.


### PR DESCRIPTION
Fixes bug that caused Elasticsearch to throw an error when an unmatched double quote was included in a keyword search.