### PR TITLE
Bugfix index template

### DIFF
--- a/cyphon/cyphon/settings/conf.example.py
+++ b/cyphon/cyphon/settings/conf.example.py
@@ -133,6 +133,10 @@ ELASTICSEARCH = {
     'KWARGS': {
         'timeout': 30,
     },
+    'INDEX': {
+        'index.mapping.ignore_malformed': True,
+        'number_of_shards': 1,
+    },
 }
 
 EMAIL = {

--- a/cyphon/cyphon/settings/default.py
+++ b/cyphon/cyphon/settings/default.py
@@ -141,6 +141,10 @@ ELASTICSEARCH = {
     'KWARGS': {
         'timeout': 30,
     },
+    'INDEX': {
+        'index.mapping.ignore_malformed': True,
+        'number_of_shards': 1,
+    },
 }
 
 EMAIL = {

--- a/cyphon/distilleries/models.py
+++ b/cyphon/distilleries/models.py
@@ -321,6 +321,18 @@ class Distillery(models.Model):
         return self.collection.name
 
     @cached_property
+    def engine(self):
+        """The |Engine| associated with the Distillery.
+
+        Returns
+        -------
+        |Engine|
+            The |Engine| that services the Distillery's |Collection|.
+
+        """
+        return self.collection.engine
+
+    @cached_property
     def warehouse(self):
         """The |Warehouse| used by the Distillery.
 

--- a/cyphon/engines/elasticsearch/client.py
+++ b/cyphon/engines/elasticsearch/client.py
@@ -35,6 +35,10 @@ import elasticsearch
 _ES_SETTINGS = settings.ELASTICSEARCH
 ES_HOSTS = _ES_SETTINGS.get('HOSTS', ['localhost:9200'])
 ES_KWARGS = _ES_SETTINGS.get('KWARGS', {'timeout': 30})
+ES_INDEX_SETTINGS = _ES_SETTINGS.get('INDEX', {
+    'index.mapping.ignore_malformed': True,
+    'number_of_shards': 1,
+})
 
 ELASTICSEARCH = elasticsearch.Elasticsearch(ES_HOSTS, **ES_KWARGS)
 

--- a/cyphon/engines/elasticsearch/engine.py
+++ b/cyphon/engines/elasticsearch/engine.py
@@ -54,7 +54,7 @@ from engines.elasticsearch import queries as es_queries
 from engines.elasticsearch import results as es_results
 from engines.elasticsearch import sorter as es_sorter
 from engines.engine import Engine, MAX_RESULTS, PAGE_SIZE
-from .client import ES_KWARGS, ELASTICSEARCH
+from .client import ELASTICSEARCH, ES_KWARGS
 from .mapper import create_mapping
 
 _LOGGER = logging.getLogger(__name__)
@@ -246,6 +246,14 @@ class ElasticsearchEngine(Engine):
             return self._index_name
 
     @property
+    def _index_for_template(self):
+        """Get the index name or pattern for creating a template."""
+        if self._in_time_series:
+            return self._index_name + '-*-*-*'
+        else:
+            return self._index_name
+
+    @property
     def _params_for_search(self):
         """Create basic parameters for searching docs.
 
@@ -263,6 +271,14 @@ class ElasticsearchEngine(Engine):
         """
         return ELASTICSEARCH.indices.exists(self._index_for_insert)
 
+    def _create_mapping(self):
+        """Create a mapping for the index.
+
+        Returns a dict of properties for mapping the data fields in
+        Elasticsearch.
+        """
+        return create_mapping(self._doc_type, self.schema)
+
     def _create_index(self):
         """Create an index for inserting docs.
 
@@ -274,13 +290,17 @@ class ElasticsearchEngine(Engine):
         params = {'index': index, 'ignore': 400, 'body': mappings}
         ELASTICSEARCH.indices.create(**params)
 
-    def _create_mapping(self):
-        """Create a mapping for the index.
+    def create_template(self):
+        """Create a template for the index.
 
-        Returns a dict of properties for mapping the data fields in
-        Elasticsearch.
+        Returns a dict of properties for an Elasticsearch index template.
         """
-        return create_mapping(self._doc_type, self.schema)
+        name = str(self)
+        body = self._create_mapping()
+        body.update({'template': self._index_for_template})
+        if ELASTICSEARCH.indices.exists_template(name):
+            ELASTICSEARCH.indices.delete_template(name)
+        ELASTICSEARCH.indices.put_template(name=name, body=body)
 
     def _filter_by_id(self, doc_ids):
         """Get docs matching one or more ids from multiple indexes.

--- a/cyphon/engines/elasticsearch/mapper.py
+++ b/cyphon/engines/elasticsearch/mapper.py
@@ -35,7 +35,7 @@ from django.conf import settings
 
 # local
 from bottler.datafields.models import DataField
-from .client import VERSION
+from .client import ES_INDEX_SETTINGS, VERSION
 
 _DATE_KEY = settings.DISTILLERIES['DATE_KEY']
 
@@ -212,9 +212,7 @@ def create_mapping(doc_type, fields):
         properties.update(prop)
 
     mappings = {
-        'settings': {
-            'index.mapping.ignore_malformed': True
-        },
+        'settings': ES_INDEX_SETTINGS,
         'mappings': {
             doc_type: properties
         }

--- a/cyphon/engines/elasticsearch/tests/test_engine.py
+++ b/cyphon/engines/elasticsearch/tests/test_engine.py
@@ -23,9 +23,9 @@ import logging
 import time
 from unittest import skipIf
 try:
-    from unittest.mock import patch
+    from unittest.mock import call, patch
 except ImportError:
-    from mock import patch
+    from mock import call, patch
 
 # third party
 from elasticsearch.exceptions import ConnectionError
@@ -313,6 +313,13 @@ class ElasticsearchHelperTestCase(ElasticsearchBaseTestCase):
         },
     }
 
+    index_settings = {
+        'settings': {
+            'index.mapping.ignore_malformed': True,
+            'number_of_shards': 1,
+        },
+    }
+
     def test_init(self):
         """
         Tests the __init__ method of an Elasticsearch object. Checks
@@ -347,30 +354,54 @@ class ElasticsearchHelperTestCase(ElasticsearchBaseTestCase):
         Tests the _create_mapping method.
         """
         actual = self.engine._create_mapping()
+        expected = self.index_settings
         if VERSION < '5.0':
-            expected = {
-                'settings': {
-                    'index.mapping.ignore_malformed': True
-                },
+            expected.update({
                 'mappings': {
                     'test_docs': {
                         'properties': self.expected_properties_v2
                     }
                 }
-            }
+            })
 
         else:
-            expected = {
-                'settings': {
-                    'index.mapping.ignore_malformed': True
-                },
+            expected.update({
                 'mappings': {
                     'test_docs': {
                         'properties': self.expected_properties_v5
                     }
                 }
-            }
+            })
         self.assertEqual(actual, expected)
+
+    @patch('engines.elasticsearch.engine.ELASTICSEARCH.indices.put_template')
+    def test_create_template(self, mock_template):
+        """
+        Tests the create_template method.
+        """
+        self.engine.create_template()
+        body = self.index_settings
+        body.update({'template': self.engine._index_for_template})
+
+        if VERSION < '5.0':
+            body.update({
+                'mappings': {
+                    'test_docs': {
+                        'properties': self.expected_properties_v2
+                    }
+                }
+            })
+        else:
+            body.update({
+                'mappings': {
+                    'test_docs': {
+                        'properties': self.expected_properties_v5
+                    }
+                }
+            })
+        mock_template.assert_has_calls([
+            call(name=str(self.engine), body=body),
+        ])
 
 
 class ElasticsearchCRUDTestCase(ElasticsearchBaseTestCase, CRUDTestCaseMixin):

--- a/cyphon/warehouses/__init__.py
+++ b/cyphon/warehouses/__init__.py
@@ -14,3 +14,4 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Cyphon Engine. If not, see <http://www.gnu.org/licenses/>.
+default_app_config = 'warehouses.apps.WarehousesConfig'

--- a/cyphon/warehouses/apps.py
+++ b/cyphon/warehouses/apps.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Dunbar Security Solutions, Inc.
+#
+# This file is part of Cyphon Engine.
+#
+# Cyphon Engine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# Cyphon Engine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Cyphon Engine. If not, see <http://www.gnu.org/licenses/>.
+"""
+Configures the :ref:`Distilleries<distilleries>` app.
+
+============================  ===============================
+Class                         Description
+============================  ===============================
+:class:`~WarehousesConfig`    |AppConfig| for |Warehouses|.
+============================  ===============================
+
+"""
+
+# third party
+from django.apps import AppConfig
+
+
+class WarehousesConfig(AppConfig):
+    """|AppConfig| for |Warehouses|."""
+
+    name = 'warehouses'
+    verbose_name = 'Warehouses'
+
+    def ready(self):
+        """Override the default :meth:`~django.apps.AppConfig.ready` method.
+
+        Registers :mod:`~warehouses.signals` used in the app.
+        """
+        import warehouses.signals  # noqa: F401

--- a/cyphon/warehouses/signals.py
+++ b/cyphon/warehouses/signals.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Dunbar Security Solutions, Inc.
+#
+# This file is part of Cyphon Engine.
+#
+# Cyphon Engine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# Cyphon Engine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Cyphon Engine. If not, see <http://www.gnu.org/licenses/>.
+"""
+Creates a signal to send when a |Distillery| saves a document.
+
+========================  ===================================
+Constant                  Description
+========================  ===================================
+:const:`~document_saved`  |Signal| that a document was saved.
+========================  ===================================
+
+"""
+
+# third party
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+# local
+from distilleries.models import Distillery
+from warehouses.models import Collection
+
+
+@receiver(post_save, sender=Distillery)
+@receiver(post_save, sender=Collection)
+def put_template(sender, instance, created, **kwargs):
+    """Create an index template."""
+    try:
+        instance.engine.create_template()
+    except AttributeError:
+        pass

--- a/cyphon/warehouses/tests/test_signals.py
+++ b/cyphon/warehouses/tests/test_signals.py
@@ -48,7 +48,7 @@ class PutTemplateTestCase(TransactionTestCase):
         distillery = Distillery.objects.get_by_natural_key(
             'elasticsearch', 'test_index', 'test_docs')
         distillery.save()
-        mock_template.assert_called_once()
+        self.assertEqual(mock_template.call_count, 1)
 
     @patch('engines.elasticsearch.engine.ElasticsearchEngine.create_template')
     def test_collection_saved(self, mock_template):
@@ -58,7 +58,7 @@ class PutTemplateTestCase(TransactionTestCase):
         collection = Collection.objects.get_by_natural_key(
             'elasticsearch', 'test_index', 'test_docs')
         collection.save()
-        mock_template.assert_called_once()
+        self.assertEqual(mock_template.call_count, 1)
 
     def test_no_template(self):
         """

--- a/cyphon/warehouses/tests/test_signals.py
+++ b/cyphon/warehouses/tests/test_signals.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Dunbar Security Solutions, Inc.
+#
+# This file is part of Cyphon Engine.
+#
+# Cyphon Engine is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License.
+#
+# Cyphon Engine is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Cyphon Engine. If not, see <http://www.gnu.org/licenses/>.
+"""
+Tests signals for Distilleries.
+"""
+
+# standard library
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+# third party
+from django.test import TransactionTestCase
+
+# local
+from distilleries.models import Distillery
+from tests.fixture_manager import get_fixtures
+from warehouses.models import Collection
+
+
+class PutTemplateTestCase(TransactionTestCase):
+    """
+    Tests the put_template signal receiver.
+    """
+
+    fixtures = get_fixtures(['distilleries'])
+
+    @patch('engines.elasticsearch.engine.ElasticsearchEngine.create_template')
+    def test_distillery_saved(self, mock_template):
+        """
+        Tests that the put_template is called when a Distllery is saved.
+        """
+        distillery = Distillery.objects.get_by_natural_key(
+            'elasticsearch', 'test_index', 'test_docs')
+        distillery.save()
+        mock_template.assert_called_once()
+
+    @patch('engines.elasticsearch.engine.ElasticsearchEngine.create_template')
+    def test_collection_saved(self, mock_template):
+        """
+        Tests that the put_template is called when a Collection is saved.
+        """
+        collection = Collection.objects.get_by_natural_key(
+            'elasticsearch', 'test_index', 'test_docs')
+        collection.save()
+        mock_template.assert_called_once()
+
+    def test_no_template(self):
+        """
+        Tests that the put_template is called when a Distllery is saved.
+        """
+        distillery = Distillery.objects.get_by_natural_key(
+            'mongodb', 'test_database', 'test_docs')
+        try:
+            distillery.save()
+        except AttributeError:
+            self.fail('put_template() raised AttributeError unexpectedly')

--- a/docs/source/modules/warehouses.apps.txt
+++ b/docs/source/modules/warehouses.apps.txt
@@ -1,0 +1,7 @@
+warehouses.apps
+===============
+
+.. automodule:: warehouses.apps
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/modules/warehouses.signals.txt
+++ b/docs/source/modules/warehouses.signals.txt
@@ -1,0 +1,7 @@
+warehouses.signals
+==================
+
+.. automodule:: warehouses.signals
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/modules/warehouses.txt
+++ b/docs/source/modules/warehouses.txt
@@ -17,6 +17,8 @@ Submodules
 .. toctree::
 
    warehouses.admin
+   warehouses.apps
    warehouses.models
    warehouses.serializers
+   warehouses.signals
    warehouses.views


### PR DESCRIPTION
Create an Elasticsearch index template when a Distillery or Collection is saved, to help avoid field mapping conflicts.