### PR TITLE
remove last_doc from Monitor serializer

### DIFF
--- a/cyphon/monitors/forms.py
+++ b/cyphon/monitors/forms.py
@@ -42,7 +42,8 @@ class MonitorForm(forms.ModelForm):
         Checks that the Monitor's Distilleries have a Datetime field
         defined.
         """
-        distilleries = self.data.get('distilleries')
+        super(MonitorForm, self).clean()
+        distilleries = self.cleaned_data.get('distilleries', [])
         for distillery_pk in distilleries:
             distillery = Distillery.objects.get(pk=distillery_pk)
             if not distillery.get_searchable_date_field():

--- a/cyphon/monitors/models.py
+++ b/cyphon/monitors/models.py
@@ -275,9 +275,8 @@ class Monitor(Alarm):
     def _update_doc_info(self):
         """
         Looks for the most recently saved doc among the Distilleries
-        being monitored, and updates the relevant filed in the Monitor.
+        being monitored, and updates the relevant field in the Monitor.
         """
-        self.last_healthy = None  # reset last_healthy
         for distillery in self.distilleries.all():
             doc = self._get_most_recent_doc(distillery)
             if doc:

--- a/cyphon/monitors/serializers.py
+++ b/cyphon/monitors/serializers.py
@@ -48,5 +48,4 @@ class MonitorSerializer(serializers.ModelSerializer):
             'last_healthy',
             'last_active_distillery',
             'last_saved_doc',
-            'last_doc',
         )

--- a/cyphon/monitors/tests/test_views.py
+++ b/cyphon/monitors/tests/test_views.py
@@ -59,7 +59,6 @@ class MonitorAPITestCase(CyphonAPITestCase):
                 'url': 'http://testserver/api/v1/distilleries/1/',
                 'id': 1
             },
-            'last_doc': '{\n    "title": "foo"\n}',
             'last_saved_doc': '10',
             'status': 'GREEN',
             'alert_level': 'HIGH',
@@ -117,7 +116,6 @@ class MonitorAPITestCase(CyphonAPITestCase):
                 ('url', 'http://testserver/api/v1/distilleries/1/')
             ])),
             ('last_saved_doc', '10'),
-            ('last_doc', '{\n    "title": "foo"\n}'),
         ])
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Removes `last_doc` from Monitor serializer to avoid calls to Elasticsearch.